### PR TITLE
correct overflowing text

### DIFF
--- a/webview-react-app/src/components/Node.tsx
+++ b/webview-react-app/src/components/Node.tsx
@@ -133,7 +133,7 @@ const Node = ({ data, handlePostMessage }: Props): JSX.Element => {
         }`}
       >
         <CardHeader>
-          <Heading size="lg" color="#FFFFFF">
+          <Heading size="lg" color="#FFFFFF" wordBreak='break-word'>
             {folderName}
           </Heading>
         </CardHeader>


### PR DESCRIPTION
Thanks for the great extension !
correct overflowing text.
https://github.com/oslabs-beta/Next-Nav/blob/c6ce976bd08a23c145652d8ebb35d1d13d824e4d/README.md?plain=1#L102

If the name of the folder were hypothetically `SampleNameChild`.


before
<img width="400" alt="スクリーンショット 2023-09-16 20 36 10" src="https://github.com/oslabs-beta/Next-Nav/assets/70254634/0a872978-3ed2-48ee-9001-37a44c6360c3">

aftrer
<img width="400" alt="スクリーンショット 2023-09-16 20 29 29" src="https://github.com/oslabs-beta/Next-Nav/assets/70254634/869d1cb8-05ed-4385-84a6-1647bcf68f0a">
